### PR TITLE
Feature/allow psu on static paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,21 +37,22 @@ application.properties:
 neverpile.url-crypto.shared-secret.enabled=true
 neverpile.url-crypto.shared-secret.secret-key=Not#So%Secret
 neverpile.url-crypto.pathPatterns=/**
-neverpile.url-crypto.enabledStaticPaths=/path/to/static/data/**
+neverpile.url-crypto.psuEnabledPathPatterns=/path/to/static/data/**
 ```
 __neverpile.url-crypto.shared-secret.enabled=true__  
 Enable the CryptoKit with a shard secret implementation.  
 This is the only implementation as of now.  
 __neverpile.url-crypto.shared-secret.secret-key=Not#So%Secret__  
 Choose a secret key for the encryption.  
+If omitted, a random secret key will be generated on startup.  
 Please don't copy the example key.  
 __neverpile.url-crypto.pathPatterns=/**__  
 Allows you to define one or multiple URL patterns where the PSU mechanism should be activated on.  
 All URL paths which do not match any of the defined paths will not be considered for encryption.  
 /&ast;&ast; will allow PSU to be enabled on all paths.  
-__neverpile.url-crypto.enabledStaticPaths=/path/to/static/data/**__  
+__neverpile.url-crypto.psuEnabledPathPatterns=/path/to/static/data/**__  
 All paths defined here should also match a pattern in the global pathPatterns property.  
-Paths defined here allow the use of PSU without any additional configuration.
+Paths defined here allow the generation of PSU with the url parameter method described in the following section.  
 
 ### Enable a handler method:
 In any Spring RestController or similar:  
@@ -69,12 +70,12 @@ public class ExampleResource {
 }
 ```
 With the `@PreSignedUrlEnabled` Annotation a single Endpoint will be registered for use with PSU.  
-Any Spring handler Method can be annotated. The annotated method must handel a path that is included in the previously 
-described `pathPatterns`.
+Any Spring handler Method can be annotated. The annotated method must handle a path that is included in the previously 
+described `pathPatterns`.  
 
 ### Generating a PSU
 If you have activated the PSU functionality on an endpoint by annotating it with `@PreSignedUrlEnabled` or by defining 
-it in the application property `enabledStaticPaths`, you can add a PSU parameter to the URL.  
+it in the application property `psuEnabledPathPatterns`, you can add a PSU parameter to the URL.  
 __example request:__  
 ```http request
 https://myhost:1337/controller/path/example/path/42?X-NPE-PSU-Duration=PT1H

--- a/README.md
+++ b/README.md
@@ -1,23 +1,98 @@
 [![Build Status](https://travis-ci.org/levigo/url-crypto-kit.svg?branch=master)](https://travis-ci.org/levigo/url-crypto-kit)
 [![Generic badge](https://img.shields.io/badge/current%20version-1.3.3-1abc9c.svg)](https://github.com/levigo/url-crypto-kit/tree/v1.3.3)
 
-# URL cryptography functionality to be used in conjunction with the Spring(tm) Framework 
+# URL cryptography functionality to be used in conjunction with the Spring&trade; Framework 
 
 ## Features
 - Pre-signed-URL generation and verification
 - URL encryption and decryption
 - integration with the Spring Framework
 - integration with Spring Security
-- Activation and configuration through Spring-Boot auto configuration
+- Activation and configuration through Spring-Boot autoconfiguration
+
+## PSU
+P(re) S(igned) U(RL) is a mechanism which enables an authenticated user to create a URL with a built-in authentication 
+for a single endpoint.  
+The PSU will enable anyone to use the requested endpoint, this URL is created for, without any additional 
+authentication.   
+This can be useful for services that can not perform the necessary authentication or simply don't have the required 
+access rights.  
+A user can only create a PSU for an endpoint he is authenticated for.  
+The Access rights of a PSU are equivalent to the user who have created it.  
+PSU are always time limited and will expire after a defined time. If the link is expired it will not provide any 
+authentication.
 
 ## Usage
-__Maven dependency__
+### Maven dependency
+```xml
+<dependency>
+    <groupId>com.neverpile</groupId>
+    <artifactId>url-crypto-kit</artifactId>
+    <version>1.3.3</version>
+</dependency>
+```
+### Example configuration
+application.properties:  
+```properties
+neverpile.url-crypto.shared-secret.enabled=true
+neverpile.url-crypto.shared-secret.secret-key=Not#So%Secret
+neverpile.url-crypto.pathPatterns=/**
+neverpile.url-crypto.enabledStaticPaths=/path/to/static/data/**
+```
+__neverpile.url-crypto.shared-secret.enabled=true__  
+Enable the CryptoKit with a shard secret implementation.  
+This is the only implementation as of now.  
+__neverpile.url-crypto.shared-secret.secret-key=Not#So%Secret__  
+Choose a secret key for the encryption.  
+Please don't copy the example key.  
+__neverpile.url-crypto.pathPatterns=/**__  
+Allows you to define one or multiple URL patterns where the PSU mechanism should be activated on.  
+All URL paths which do not match any of the defined paths will not be considered for encryption.  
+/&ast;&ast; will allow PSU to be enabled on all paths.  
+__neverpile.url-crypto.enabledStaticPaths=/path/to/static/data/**__  
+All paths defined here should also match a pattern in the global pathPatterns property.  
+Paths defined here allow the use of PSU without any additional configuration.
 
-    <dependency>
-        <groupId>com.neverpile</groupId>
-        <artifactId>url-crypto-kit</artifactId>
-        <version>1.3.3</version>
-    </dependency>
+### Enable a handler method:
+In any Spring RestController or similar:  
+```JAVA
+@RestController
+@RequestMapping("/controller/path")
+public class ExampleResource {
+  
+  @GetMapping("/example/path/{id}")
+  @PreSignedUrlEnabled
+  public @ResponseBody ResponseEntity<Resource> getData(@PathVariable String id) {
+    return ResponseEntity.ok().build();
+  }
+  
+}
+```
+With the `@PreSignedUrlEnabled` Annotation a single Endpoint will be registered for use with PSU.  
+Any Spring handler Method can be annotated. The annotated method must handel a path that is included in the previously 
+described `pathPatterns`.
+
+### Generating a PSU
+If you have activated the PSU functionality on an endpoint by annotating it with `@PreSignedUrlEnabled` or by defining 
+it in the application property `enabledStaticPaths`, you can add a PSU parameter to the URL.  
+__example request:__  
+```http request
+https://myhost:1337/controller/path/example/path/42?X-NPE-PSU-Duration=PT1H
+```
+`X-NPE-PSU-Duration` has to be the parameter key and the value can be any duration as text.  
+The formats accepted are based on the ISO-8601 duration format `PnDTnHnMn.nS`.  
+The request with the added PSU parameter has to be authenticated, because the current user authentication will be used 
+in the resulting PSU.  
+The endpoint will return a PSU as plain text and will not execute its own functionality.  
+__example result:__  
+```http request
+https://myhost:1337/controller/path/example/path/42?X-NPE-PSU-Expires=20221121223924&X-NPE-PSU-Signature=cfa1dd7db3e67208fc59abd6b78fc7d70b422ad7ccef97b7680bef4299c3d404&X-NPE-PSU-Credential=FiQXra5CW9kEHVV6wkVazKBw2FmLXmQ7pDQiCKkWxZWtdXjrEPdUM8bAVj5gLrVs
+```
+
+The result link includes a date which indicates how long this link is valid for and the encrypted authentication info.  
+If this link is used by any user or application the user gains access rights corresponding to the user who created the 
+link.  
+Any endpoint with enabled PSU can be used as normal without the PSU URL parameter.  
 
 ## License
 This library is provided "as is" under the "three-clause BSD license". See [LICENSE.md](./LICENSE.md).

--- a/src/main/java/com/neverpile/urlcrypto/config/UrlCryptoConfiguration.java
+++ b/src/main/java/com/neverpile/urlcrypto/config/UrlCryptoConfiguration.java
@@ -18,14 +18,16 @@ public class UrlCryptoConfiguration {
   private String enablePreSignedUrlAnnotationClass = PreSignedUrlEnabled.class.getName();
 
   private final SharedSecretConfiguration sharedSecret = new SharedSecretConfiguration();
-  
+
   private Duration maxPreSignedValidity = Duration.ofDays(30);
-  
+
   private List<String> pathPatterns = new ArrayList<>(Collections.singletonList("/**"));
-  
+
+  private List<String> enabledStaticPaths = new ArrayList<>();
+
   public static class SharedSecretConfiguration {
     private boolean enabled;
-    
+
     private String secretKey;
 
     public boolean isEnabled() {
@@ -71,5 +73,13 @@ public class UrlCryptoConfiguration {
 
   public void setPathPatterns(final List<String> pathPatterns) {
     this.pathPatterns = pathPatterns;
+  }
+
+  public List<String> getEnabledStaticPaths() {
+    return enabledStaticPaths;
+  }
+
+  public void setEnabledStaticPaths(List<String> enabledStaticPaths) {
+    this.enabledStaticPaths = enabledStaticPaths;
   }
 }

--- a/src/main/java/com/neverpile/urlcrypto/config/UrlCryptoConfiguration.java
+++ b/src/main/java/com/neverpile/urlcrypto/config/UrlCryptoConfiguration.java
@@ -23,7 +23,7 @@ public class UrlCryptoConfiguration {
 
   private List<String> pathPatterns = new ArrayList<>(Collections.singletonList("/**"));
 
-  private List<String> enabledStaticPaths = new ArrayList<>();
+  private List<String> psuEnabledPathPatterns = new ArrayList<>();
 
   public static class SharedSecretConfiguration {
     private boolean enabled;
@@ -75,11 +75,11 @@ public class UrlCryptoConfiguration {
     this.pathPatterns = pathPatterns;
   }
 
-  public List<String> getEnabledStaticPaths() {
-    return enabledStaticPaths;
+  public List<String> getPsuEnabledPathPatterns() {
+    return psuEnabledPathPatterns;
   }
 
-  public void setEnabledStaticPaths(List<String> enabledStaticPaths) {
-    this.enabledStaticPaths = enabledStaticPaths;
+  public void setPsuEnabledPathPatterns(List<String> psuEnabledPathPatterns) {
+    this.psuEnabledPathPatterns = psuEnabledPathPatterns;
   }
 }

--- a/src/main/java/com/neverpile/urlcrypto/springsecurity/GeneratePreSignedUrlInterceptor.java
+++ b/src/main/java/com/neverpile/urlcrypto/springsecurity/GeneratePreSignedUrlInterceptor.java
@@ -55,8 +55,9 @@ public class GeneratePreSignedUrlInterceptor implements HandlerInterceptor {
           return generatePreSignedUrl(request, response, requestedExpiryTime);
         }
       } else if (handler instanceof ResourceHttpRequestHandler) {
-        if (isEnabledStaticPath(request)) {
-          throw new AuthenticationException("Pre Sign URLs(PSU) not enabled for " + request.getRequestURL().toString()) {
+        if (!isEnabledStaticPath(request)) {
+          throw new AuthenticationException("Pre Sign URLs(PSU) not enabled for " + request.getRequestURL().toString() +
+              "\nAdd a matching url pattern to your app property 'neverpile.url-crypto.psuEnabledPathPatterns'.") {
             private static final long serialVersionUID = 1L;
           };
         } else {
@@ -69,7 +70,7 @@ public class GeneratePreSignedUrlInterceptor implements HandlerInterceptor {
 
   private boolean isEnabledStaticPath(HttpServletRequest request) {
     PathPatternParser ppp = new PathPatternParser();
-    return config.getPsuEnabledPathPatterns().stream().noneMatch(
+    return config.getPsuEnabledPathPatterns().stream().anyMatch(
         s -> ppp.parse(s).matches(PathContainer.parsePath(request.getServletPath()))
     );
   }

--- a/src/main/java/com/neverpile/urlcrypto/springsecurity/GeneratePreSignedUrlInterceptor.java
+++ b/src/main/java/com/neverpile/urlcrypto/springsecurity/GeneratePreSignedUrlInterceptor.java
@@ -69,7 +69,7 @@ public class GeneratePreSignedUrlInterceptor implements HandlerInterceptor {
 
   private boolean isEnabledStaticPath(HttpServletRequest request) {
     PathPatternParser ppp = new PathPatternParser();
-    return config.getEnabledStaticPaths().stream().noneMatch(
+    return config.getPsuEnabledPathPatterns().stream().noneMatch(
         s -> ppp.parse(s).matches(PathContainer.parsePath(request.getServletPath()))
     );
   }

--- a/src/main/java/com/neverpile/urlcrypto/springsecurity/GeneratePreSignedUrlInterceptor.java
+++ b/src/main/java/com/neverpile/urlcrypto/springsecurity/GeneratePreSignedUrlInterceptor.java
@@ -9,12 +9,15 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.server.PathContainer;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import com.neverpile.urlcrypto.UrlCryptoKit;
 import com.neverpile.urlcrypto.config.UrlCryptoConfiguration;
+import org.springframework.web.servlet.resource.ResourceHttpRequestHandler;
+import org.springframework.web.util.pattern.PathPatternParser;
 
 public class GeneratePreSignedUrlInterceptor implements HandlerInterceptor {
 
@@ -49,20 +52,41 @@ public class GeneratePreSignedUrlInterceptor implements HandlerInterceptor {
             private static final long serialVersionUID = 1L;
           };
         } else {
-          Duration expiryTime = parse(requestedExpiryTime);
-
-          // limit validity to configured maximum
-          if (null != config.getMaxPreSignedValidity() && expiryTime.compareTo(config.getMaxPreSignedValidity()) > 0)
-            expiryTime = config.getMaxPreSignedValidity();
-
-          String url = crypto.generatePreSignedUrl(expiryTime, request.getRequestURL().toString());
-
-          response.setContentType("text/uri-list");
-          response.getWriter().write(url + "\r\n");
-          return false;
+          return generatePreSignedUrl(request, response, requestedExpiryTime);
+        }
+      } else if (handler instanceof ResourceHttpRequestHandler) {
+        if (isEnabledStaticPath(request)) {
+          throw new AuthenticationException("Pre Sign URLs(PSU) not enabled for " + request.getRequestURL().toString()) {
+            private static final long serialVersionUID = 1L;
+          };
+        } else {
+          return generatePreSignedUrl(request, response, requestedExpiryTime);
         }
       }
     }
     return true;
+  }
+
+  private boolean isEnabledStaticPath(HttpServletRequest request) {
+    PathPatternParser ppp = new PathPatternParser();
+    return config.getEnabledStaticPaths().stream().noneMatch(
+        s -> ppp.parse(s).matches(PathContainer.parsePath(request.getServletPath()))
+    );
+  }
+
+  private boolean generatePreSignedUrl(HttpServletRequest request, HttpServletResponse response, String requestedExpiryTime)
+      throws Exception {
+    Duration expiryTime = parse(requestedExpiryTime);
+
+    // limit validity to configured maximum
+    if (null != config.getMaxPreSignedValidity() && expiryTime.compareTo(config.getMaxPreSignedValidity()) > 0) {
+      expiryTime = config.getMaxPreSignedValidity();
+    }
+
+    String url = crypto.generatePreSignedUrl(expiryTime, request.getRequestURL().toString());
+
+    response.setContentType("text/uri-list");
+    response.getWriter().write(url + "\r\n");
+    return false;
   }
 }


### PR DESCRIPTION
Hintergrund: 
Bisher können Ressourcen nur über die `@PreSignedUrlEnabled` Annotation auf einer Spring `HandlerMethod` 
abgesichert werden. Wenn Resourcen auf einem statisch verfügbaren Pfad oder über einen Spring `ResourceHandler` zur Verfügung gestellt werden, gibt es bisher keine Möglichkeit den PSU Mechanismus zu aktivieren. 

Die neue Property `psuEnabledPathPatterns` lässt beliebig viele URL-Patterns definieren, die automatisch in den PSU Mechanismus mit aufgenommen werden.